### PR TITLE
Add the ability to override content_item_defaults again

### DIFF
--- a/p2p/__init__.py
+++ b/p2p/__init__.py
@@ -98,6 +98,7 @@ class P2P(object):
     def __init__(self, url, auth_token,
                  debug=False, cache=NoCache(),
                  image_services_url=None,
+                 content_item_defaults=None,
                  product_affiliate_code='chinews',
                  source_code='chicagotribune',
                  webapp_name='tRibbit'):
@@ -122,7 +123,7 @@ class P2P(object):
             'filter': self.default_filter
         }
 
-        self.content_item_defaults = {
+        self.content_item_defaults = content_item_defaults or {
             "content_item_type_code": "blurb",
             "product_affiliate_code": self.product_affiliate_code,
             "source_code": self.source_code,


### PR DESCRIPTION
This ability got lost in the shuffle. Could just create options for content_item_type_code and state_code so we can do non-blurb / non-live items, but overriding content_item_defaults was how it was set up previously.
